### PR TITLE
Rustfmt and some clippy warnings and errors

### DIFF
--- a/benches/delaunator.rs
+++ b/benches/delaunator.rs
@@ -1,94 +1,168 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use voronator::delaunator::{triangulate, Point};
-use rand::Rng;
 use rand::distributions::Uniform;
+use rand::Rng;
 use rand_distr::StandardNormal;
+use voronator::delaunator::{triangulate, Point};
 
 pub fn uniform20000(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let range = Uniform::new(0., 1000.);
-    let points: Vec<Point> = (0..20000).map(|_| Point {x: rng.sample(&range), y: rng.sample(&range)}).collect();
+    let points: Vec<Point> = (0..20000)
+        .map(|_| Point {
+            x: rng.sample(&range),
+            y: rng.sample(&range),
+        })
+        .collect();
 
-    c.bench_function("uniform 20k", |b| b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input.")));
+    c.bench_function("uniform 20k", |b| {
+        b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input."))
+    });
 }
 
 pub fn uniform100000(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let range = Uniform::new(0., 1000.);
-    let points: Vec<Point> = (0..100000).map(|_| Point {x: rng.sample(&range), y: rng.sample(&range)}).collect();
+    let points: Vec<Point> = (0..100000)
+        .map(|_| Point {
+            x: rng.sample(&range),
+            y: rng.sample(&range),
+        })
+        .collect();
 
-    c.bench_function("uniform 100k", |b| b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input.")));
+    c.bench_function("uniform 100k", |b| {
+        b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input."))
+    });
 }
 
 pub fn uniform200000(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let range = Uniform::new(0., 1000.);
-    let points: Vec<Point> = (0..200000).map(|_| Point {x: rng.sample(&range), y: rng.sample(&range)}).collect();
+    let points: Vec<Point> = (0..200000)
+        .map(|_| Point {
+            x: rng.sample(&range),
+            y: rng.sample(&range),
+        })
+        .collect();
 
-    c.bench_function("uniform 200k", |b| b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input.")));
+    c.bench_function("uniform 200k", |b| {
+        b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input."))
+    });
 }
 
 pub fn uniform500000(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let range = Uniform::new(0., 1000.);
-    let points: Vec<Point> = (0..500000).map(|_| Point {x: rng.sample(&range), y: rng.sample(&range)}).collect();
+    let points: Vec<Point> = (0..500000)
+        .map(|_| Point {
+            x: rng.sample(&range),
+            y: rng.sample(&range),
+        })
+        .collect();
 
-    c.bench_function("uniform 500k", |b| b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input.")));
+    c.bench_function("uniform 500k", |b| {
+        b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input."))
+    });
 }
 
 pub fn uniform1000000(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let range = Uniform::new(0., 1000.);
-    let points: Vec<Point> = (0..1000000).map(|_| Point {x: rng.sample(&range), y: rng.sample(&range)}).collect();
+    let points: Vec<Point> = (0..1000000)
+        .map(|_| Point {
+            x: rng.sample(&range),
+            y: rng.sample(&range),
+        })
+        .collect();
 
-    c.bench_function("uniform 1M", |b| b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input.")));
+    c.bench_function("uniform 1M", |b| {
+        b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input."))
+    });
 }
 
 pub fn gaussian20000(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let points: Vec<Point> = (0..20000)
-        .map(|_| Point {x: rng.sample::<f64,StandardNormal>(StandardNormal) * 1000., y: rng.sample::<f64,StandardNormal>(StandardNormal) * 1000.})
+        .map(|_| Point {
+            x: rng.sample::<f64, StandardNormal>(StandardNormal) * 1000.,
+            y: rng.sample::<f64, StandardNormal>(StandardNormal) * 1000.,
+        })
         .collect();
 
-    c.bench_function("gaussian 20k", |b| b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input.")));
+    c.bench_function("gaussian 20k", |b| {
+        b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input."))
+    });
 }
 
 pub fn gaussian100000(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let points: Vec<Point> = (0..100000)
-        .map(|_| Point {x: rng.sample::<f64,StandardNormal>(StandardNormal) * 1000., y: rng.sample::<f64,StandardNormal>(StandardNormal) * 1000.})
+        .map(|_| Point {
+            x: rng.sample::<f64, StandardNormal>(StandardNormal) * 1000.,
+            y: rng.sample::<f64, StandardNormal>(StandardNormal) * 1000.,
+        })
         .collect();
 
-    c.bench_function("gaussian 100k", |b| b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input.")));
+    c.bench_function("gaussian 100k", |b| {
+        b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input."))
+    });
 }
 
 pub fn gaussian200000(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let points: Vec<Point> = (0..200000)
-        .map(|_| Point {x: rng.sample::<f64,StandardNormal>(StandardNormal) * 1000., y: rng.sample::<f64,StandardNormal>(StandardNormal) * 1000.})
+        .map(|_| Point {
+            x: rng.sample::<f64, StandardNormal>(StandardNormal) * 1000.,
+            y: rng.sample::<f64, StandardNormal>(StandardNormal) * 1000.,
+        })
         .collect();
 
-    c.bench_function("gaussian 200k", |b| b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input.")));
+    c.bench_function("gaussian 200k", |b| {
+        b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input."))
+    });
 }
 
 pub fn gaussian500000(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let points: Vec<Point> = (0..500000)
-        .map(|_| Point {x: rng.sample::<f64,StandardNormal>(StandardNormal) * 1000., y: rng.sample::<f64,StandardNormal>(StandardNormal) * 1000.})
+        .map(|_| Point {
+            x: rng.sample::<f64, StandardNormal>(StandardNormal) * 1000.,
+            y: rng.sample::<f64, StandardNormal>(StandardNormal) * 1000.,
+        })
         .collect();
 
-    c.bench_function("gaussian 500k", |b| b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input.")));
+    c.bench_function("gaussian 500k", |b| {
+        b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input."))
+    });
 }
 
 pub fn gaussian1000000(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let points: Vec<Point> = (0..1000000)
-        .map(|_| Point {x: rng.sample::<f64,StandardNormal>(StandardNormal) * 1000., y: rng.sample::<f64,StandardNormal>(StandardNormal) * 1000.})
+        .map(|_| Point {
+            x: rng.sample::<f64, StandardNormal>(StandardNormal) * 1000.,
+            y: rng.sample::<f64, StandardNormal>(StandardNormal) * 1000.,
+        })
         .collect();
 
-    c.bench_function("gaussian 1M", |b| b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input.")));
+    c.bench_function("gaussian 1M", |b| {
+        b.iter(|| triangulate(black_box(&points)).expect("No triangulation exists for this input."))
+    });
 }
 
-criterion_group!(uniform, uniform20000, uniform100000, uniform200000, uniform500000, uniform1000000);
-criterion_group!(gaussian, gaussian20000, gaussian100000, gaussian200000, gaussian500000, gaussian1000000);
+criterion_group!(
+    uniform,
+    uniform20000,
+    uniform100000,
+    uniform200000,
+    uniform500000,
+    uniform1000000
+);
+criterion_group!(
+    gaussian,
+    gaussian20000,
+    gaussian100000,
+    gaussian200000,
+    gaussian500000,
+    gaussian1000000
+);
 criterion_main!(uniform, gaussian);

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,12 +1,12 @@
 extern crate voronator;
 
-use rand::Rng;
 use rand::distributions::Uniform;
+use rand::Rng;
 use rand_distr::StandardNormal;
-use voronator::delaunator as delaunator;
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
+use voronator::delaunator;
 
-use std::f64 as f64;
+use std::f64;
 
 fn report(n: usize, elapsed: Duration, t: &delaunator::Triangulation) {
     println!(
@@ -26,7 +26,12 @@ fn uniform(count: &[usize]) {
     println!("Uniform distribution:");
 
     for c in count {
-        let points: Vec<delaunator::Point> = (0..*c).map(|_| delaunator::Point {x: rng.sample(&range), y: rng.sample(&range)}).collect();
+        let points: Vec<delaunator::Point> = (0..*c)
+            .map(|_| delaunator::Point {
+                x: rng.sample(&range),
+                y: rng.sample(&range),
+            })
+            .collect();
 
         let now = Instant::now();
         let t = delaunator::triangulate(&points).expect("No triangulation exists for this input.");
@@ -38,12 +43,15 @@ fn uniform(count: &[usize]) {
 
 fn gaussian(count: &[usize]) {
     let mut rng = rand::thread_rng();
-    
+
     println!("Gaussian distribution:");
 
     for c in count {
         let points: Vec<delaunator::Point> = (0..*c)
-            .map(|_| delaunator::Point {x: rng.sample::<f64,StandardNormal>(StandardNormal) * 1000., y: rng.sample::<f64,StandardNormal>(StandardNormal) * 1000.})
+            .map(|_| delaunator::Point {
+                x: rng.sample::<f64, StandardNormal>(StandardNormal) * 1000.,
+                y: rng.sample::<f64, StandardNormal>(StandardNormal) * 1000.,
+            })
             .collect();
 
         let now = Instant::now();
@@ -60,10 +68,13 @@ fn grid(count: &[usize]) {
     for c in count {
         let size = (*c as f64).sqrt().floor() as usize;
         let mut points: Vec<delaunator::Point> = vec![];
-        
+
         for i in 0..size {
             for j in 0..size {
-                points.push(delaunator::Point{x: i as f64, y: j as f64});
+                points.push(delaunator::Point {
+                    x: i as f64,
+                    y: j as f64,
+                });
             }
         }
 
@@ -79,10 +90,13 @@ fn degenerate(count: &[usize]) {
     println!("Degenerate distribution:");
 
     for c in count {
-        let mut points: Vec<delaunator::Point> = vec![delaunator::Point{x: 0., y: 0.}];
+        let mut points: Vec<delaunator::Point> = vec![delaunator::Point { x: 0., y: 0. }];
         for i in 0..*c {
             let angle = 2. * f64::consts::PI * (i as f64) / (*c as f64);
-            points.push(delaunator::Point{x: 1e10 * angle.sin(), y: 1e10 * angle.cos()});
+            points.push(delaunator::Point {
+                x: 1e10 * angle.sin(),
+                y: 1e10 * angle.cos(),
+            });
         }
 
         let now = Instant::now();

--- a/examples/plot-triangulation.rs
+++ b/examples/plot-triangulation.rs
@@ -1,17 +1,19 @@
-extern crate voronator;
 extern crate plotters;
 extern crate rand;
+extern crate voronator;
 
-use voronator::delaunator::{triangulate_from_tuple};
 use plotters::prelude::*;
 use rand::prelude::*;
 use rand_distr::Uniform;
+use voronator::delaunator::triangulate_from_tuple;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut rng = rand::thread_rng();
     let range = Uniform::new(0., 1000.);
-    let points: Vec<(f64, f64)> = (0..1000).map(|_| (rng.sample(&range), rng.sample(&range))).collect();
-    
+    let points: Vec<(f64, f64)> = (0..1000)
+        .map(|_| (rng.sample(&range), rng.sample(&range)))
+        .collect();
+
     let (t, ps) = triangulate_from_tuple(&points).expect("No triangulation exists for this input.");
 
     let root = BitMapBackend::new("plot.png", (960, 400)).into_drawing_area();
@@ -24,15 +26,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ));
 
     for i in 0..t.len() {
-        let i0 = t.triangles[3*i];
-        let i1 = t.triangles[3*i + 1];
-        let i2 = t.triangles[3*i + 2];
+        let i0 = t.triangles[3 * i];
+        let i1 = t.triangles[3 * i + 1];
+        let i2 = t.triangles[3 * i + 2];
 
-        let p = vec![(ps[i0].x as f32, ps[i0].y as f32), 
-                     (ps[i1].x as f32, ps[i1].y as f32), 
-                     (ps[i2].x as f32, ps[i2].y as f32)];
-        
-        let color = RGBColor{0: rng.gen(), 1: rng.gen(), 2: rng.gen()};
+        let p = vec![
+            (ps[i0].x as f32, ps[i0].y as f32),
+            (ps[i1].x as f32, ps[i1].y as f32),
+            (ps[i2].x as f32, ps[i2].y as f32),
+        ];
+
+        let color = RGBColor {
+            0: rng.gen(),
+            1: rng.gen(),
+            2: rng.gen(),
+        };
         let poly = Polygon::new(p.clone(), Into::<ShapeStyle>::into(&color));
         root.draw(&poly)?;
     }
@@ -40,7 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for point in &ps {
         let p = (point.x as f32, point.y as f32);
         root.draw(&Circle::new(p, 3, ShapeStyle::from(&BLACK).filled()))?;
-    }   
- 
+    }
+
     Ok(())
 }

--- a/examples/plot-voronoi.rs
+++ b/examples/plot-voronoi.rs
@@ -1,12 +1,12 @@
-extern crate voronator;
 extern crate plotters;
 extern crate rand;
+extern crate voronator;
 
+use plotters::prelude::*;
+use rand::prelude::*;
 use voronator::delaunator::Point;
 #[allow(unused_imports)]
 use voronator::{CentroidDiagram, VoronoiDiagram};
-use plotters::prelude::*;
-use rand::prelude::*;
 
 const IMG_WIDTH: u32 = 500;
 const IMG_HEIGHT: u32 = 500;
@@ -14,15 +14,15 @@ const IMG_HEIGHT: u32 = 500;
 fn get_points(n: i32, jitter: f64) -> Vec<Point> {
     let mut rng = rand::thread_rng();
     let mut points: Vec<Point> = vec![];
-    for i in 0..n+1 {
-        for j in 0..n+1 {
-            points.push(Point{
-                x: (i as f64) + jitter * (rng.gen::<f64>() - rng.gen::<f64>()), 
-                y: (j as f64) + jitter * (rng.gen::<f64>() - rng.gen::<f64>()) 
+    for i in 0..n + 1 {
+        for j in 0..n + 1 {
+            points.push(Point {
+                x: (i as f64) + jitter * (rng.gen::<f64>() - rng.gen::<f64>()),
+                y: (j as f64) + jitter * (rng.gen::<f64>() - rng.gen::<f64>()),
             });
         }
     }
-    
+
     points
 }
 
@@ -32,15 +32,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let size = 10;
     let points: Vec<Point> = get_points(size, 0.6)
         .into_iter()
-        .map(|p| Point{
-            x: ((IMG_WIDTH as f64) / 20. + p.x * (IMG_WIDTH as f64)) / (size as f64), 
-            y: ((IMG_HEIGHT as f64) / 20. + p.y * (IMG_HEIGHT as f64)) / (size as f64)
-        }).collect();
+        .map(|p| Point {
+            x: ((IMG_WIDTH as f64) / 20. + p.x * (IMG_WIDTH as f64)) / (size as f64),
+            y: ((IMG_HEIGHT as f64) / 20. + p.y * (IMG_HEIGHT as f64)) / (size as f64),
+        })
+        .collect();
 
     let now = std::time::Instant::now();
-    let diagram = VoronoiDiagram::new(&Point{x: 0., y: 0.}, &Point{x: IMG_WIDTH as f64, y: IMG_HEIGHT as f64}, &points).unwrap();
+    let diagram = VoronoiDiagram::new(
+        &Point { x: 0., y: 0. },
+        &Point {
+            x: IMG_WIDTH as f64,
+            y: IMG_HEIGHT as f64,
+        },
+        &points,
+    )
+    .unwrap();
     // let diagram = CentroidDiagram::new(&points).unwrap();
-    println!("time it took to generating a diagram for {} points: {}ms", points.len(), now.elapsed().as_millis());
+    println!(
+        "time it took to generating a diagram for {} points: {}ms",
+        points.len(),
+        now.elapsed().as_millis()
+    );
 
     let root = BitMapBackend::new("plot.png", (IMG_WIDTH, IMG_HEIGHT)).into_drawing_area();
     root.fill(&WHITE)?;
@@ -66,10 +79,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let p: Vec<(f32, f32)> = cell.into_iter().map(|x| (x.x as f32, x.y as f32)).collect();
 
         for _ in 0..p.len() {
-            let plot = PathElement::new(p.clone(), ShapeStyle{color: BLACK.to_rgba(), filled: true, stroke_width: 1});    
-            root.draw(&plot)?;    
+            let plot = PathElement::new(
+                p.clone(),
+                ShapeStyle {
+                    color: BLACK.to_rgba(),
+                    filled: true,
+                    stroke_width: 1,
+                },
+            );
+            root.draw(&plot)?;
         }
     }
- 
+
     Ok(())
 }

--- a/examples/plot-voronoi.rs
+++ b/examples/plot-voronoi.rs
@@ -27,8 +27,6 @@ fn get_points(n: i32, jitter: f64) -> Vec<Point> {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-
     let size = 10;
     let points: Vec<Point> = get_points(size, 0.6)
         .into_iter()

--- a/examples/simple-triangulation.rs
+++ b/examples/simple-triangulation.rs
@@ -1,12 +1,14 @@
 extern crate voronator;
 
-use voronator::delaunator as delaunator;
+use voronator::delaunator;
 
 fn main() {
     let coords = vec![(0., 0.), (1., 0.), (1., 1.), (0., 1.)];
     let (triangulation, _) = delaunator::triangulate_from_tuple(&coords).unwrap();
 
-    println!("Triangulated  {} points, generating {} triangles.",
+    println!(
+        "Triangulated  {} points, generating {} triangles.",
         coords.len(),
-        triangulation.triangles.len() / 3);
+        triangulation.triangles.len() / 3
+    );
 }

--- a/src/clip.rs
+++ b/src/clip.rs
@@ -185,6 +185,7 @@ pub fn clip_finite(points: &[Point], min: &Point, max: &Point) -> Vec<Point> {
 }
 
 #[rustfmt::skip]
+
 pub fn clip_infinite(
     points: &[Point],
     v0: &Point,

--- a/src/clip.rs
+++ b/src/clip.rs
@@ -99,17 +99,17 @@ fn contains(points: &[Point], v0: &Point, vn: &Point, p: &Point) -> bool {
 }
 
 fn sidecode(p: &Point, min: &Point, max: &Point) -> usize {
-    let part1 = if p.x == min.x {
+    let part1 = if (p.x - min.x).abs() < std::f64::EPSILON {
         1
-    } else if p.x == max.x {
+    } else if (p.x - max.x).abs() < std::f64::EPSILON {
         2
     } else {
         0
     };
 
-    let part2 = if p.y == min.y {
+    let part2 = if (p.y - min.y).abs() < std::f64::EPSILON {
         4
-    } else if p.y == max.y {
+    } else if (p.y - max.y).abs() < std::f64::EPSILON {
         8
     } else {
         0
@@ -193,7 +193,7 @@ pub fn clip_infinite(
     min: &Point,
     max: &Point,
 ) -> Vec<Point> {
-    let mut clipped = points.clone().to_vec();
+    let mut clipped = points.to_vec();
     let mut n: usize;
 
     let p = project(&clipped[0], v0, min, max);
@@ -230,7 +230,7 @@ pub fn clip_infinite(
                         0b0001 => { c0 = 0b0101; c = Point{x: min.x, y: min.y}; } // left
                         _      => { panic!("this should never be reachable")}
                     }
-                    if (clipped[i].x != c.x || clipped[i].y != c.y) && contains(points, v0, vn, &c)
+                    if ( (clipped[i].x - c.x).abs() > std::f64::EPSILON || (clipped[i].y - c.y).abs() > std::f64::EPSILON) && contains(points, v0, vn, &c)
                     {
                         clipped.insert(i, c);
                         i += 1;

--- a/src/delaunator.rs
+++ b/src/delaunator.rs
@@ -683,9 +683,7 @@ fn find_seed_triangle(center: &Point, points: &[Point]) -> Option<(usize, usize,
         let p2 = &points[i2];
 
         if counter_clockwise(&p0, &p1, &p2) {
-            let temp = i1;
-            i1 = i2;
-            i2 = temp;
+            std::mem::swap(&mut i1, &mut i2)
         }
 
         Some((i0, i1, i2))

--- a/src/delaunator.rs
+++ b/src/delaunator.rs
@@ -1,7 +1,7 @@
 #![warn(missing_docs)]
 #![warn(missing_doc_code_examples)]
 //! Implements the Delaunay triangulation algorithm.
-//! 
+//!
 //! This module was ported from the original [Delaunator](https://github.com/mapbox/delaunator), by Mapbox. If a triangulation is possible a given set of points in the 2D space, it returns a [`Triangulation`] structure. This structure contains three main components: [`triangles`], [`halfedges`] and [`hull`]:
 //! ```ignore
 //! let coords = vec![(0., 0.), (1., 0.), (1., 1.), (0., 1.)];
@@ -21,41 +21,40 @@
 //! ```
 //! - `halfedges`:  `Vec<usize>` array of triangle half-edge indices that allows you to traverse the triangulation. i-th half-edge in the array corresponds to vertex `triangles[i]` the half-edge is coming from. `halfedges[i]` is the index of a twin half-edge in an adjacent triangle (or `INVALID_INDEX` for outer half-edges on the convex hull). The flat array-based data structures might be counterintuitive, but they're one of the key reasons this library is fast.
 //! - `hull`: A `Vec<usize>` array of indices that reference points on the convex hull of the input data, counter-clockwise.
-//! 
+//!
 //! The last two components, `inedges` and `outedges`, are for voronator internal use only.
-//! 
+//!
 //! # Example
-//! 
+//!
 //! ```no_run
 //! extern crate voronator;
-//! 
+//!
 //! use voronator::delaunator::{triangulate_from_tuple};
-//! 
+//!
 //! fn main() {
 //!     let points = vec![(0., 0.), (1., 0.), (1., 1.), (0., 1.)];
-//!     
+//!
 //!     let (t, _) = triangulate_from_tuple(&points)
 //!         .expect("No triangulation exists for this input.");
-//! 
+//!
 //!     for i in 0..t.len() {
 //!         let i0 = t.triangles[3*i];
 //!         let i1 = t.triangles[3*i + 1];
 //!         let i2 = t.triangles[3*i + 2];
-//! 
+//!
 //!         let p = vec![points[i0], points[i1], points[i2]];
-//! 
+//!
 //!         println!("triangle {}: {:?}", i, p);
 //!     }
 //! }
 //! ```
-//! 
+//!
 //! [`Triangulation`]: ./struct.Triangulation.html
 //! [`triangles`]: ./struct.Triangulation.html#structfield.triangles
 //! [`halfedges`]: ./struct.Triangulation.html#structfield.halfedges
 //! [`hull`]: ./struct.Triangulation.html#structfield.hull
 
-use std::{f64, usize, fmt};
-use vec;
+use std::{f64, fmt, usize};
 
 /// Defines a comparison epsilon used for floating-point comparissons
 pub const EPSILON: f64 = f64::EPSILON * 2.0;
@@ -64,12 +63,12 @@ pub const EPSILON: f64 = f64::EPSILON * 2.0;
 pub const INVALID_INDEX: usize = usize::max_value();
 
 #[derive(Clone, PartialEq)]
-/// Represents a point in the 2D space. 
+/// Represents a point in the 2D space.
 pub struct Point {
     /// X coordinate of the point
     pub x: f64,
     /// Y coordinate of the point
-    pub y: f64
+    pub y: f64,
 }
 
 impl fmt::Debug for Point {
@@ -82,7 +81,7 @@ impl Point {
     fn vector(p: &Self, q: &Self) -> Self {
         Self {
             x: q.x - p.x,
-            y: q.y - p.y
+            y: q.y - p.y,
         }
     }
 
@@ -111,10 +110,12 @@ impl Point {
 
 impl From<(f64, f64)> for Point {
     fn from(item: (f64, f64)) -> Self {
-        Point{x: item.0, y: item.1}
+        Point {
+            x: item.0,
+            y: item.1,
+        }
     }
 }
-
 
 fn in_circle(p: &Point, a: &Point, b: &Point, c: &Point) -> bool {
     let d = Point::vector(p, a);
@@ -125,14 +126,16 @@ fn in_circle(p: &Point, a: &Point, b: &Point, c: &Point) -> bool {
     let bp = e.x * e.x + e.y * e.y;
     let cp = f.x * f.x + f.y * f.y;
 
+    #[rustfmt::skip]
     let res = d.x * (e.y * cp  - bp  * f.y) -
                    d.y * (e.x * cp  - bp  * f.x) +
                    ap  * (e.x * f.y - e.y * f.x) ;
-     
-     res < 0.0
+
+    res < 0.0
 }
 
-fn circumradius(a: &Point, b: &Point, c: &Point) -> f64{
+#[rustfmt::skip]
+fn circumradius(a: &Point, b: &Point, c: &Point) -> f64 {
     let d = Point::vector(a, b);
     let e = Point::vector(a, c);
 
@@ -153,12 +156,13 @@ fn circumradius(a: &Point, b: &Point, c: &Point) -> f64{
 }
 
 /// Calculates the circumcenter of a triangle, given it's three vertices
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `a` - The first vertex of the triangle
 /// * `b` - The second vertex of the triangle
 /// * `c` - The third vertex of the triangle
+#[rustfmt::skip]
 pub fn circumcenter(a: &Point, b: &Point, c: &Point) -> Option<Point> {
     let d = Point::vector(a, b);
     let e = Point::vector(a, c);
@@ -175,7 +179,7 @@ pub fn circumcenter(a: &Point, b: &Point, c: &Point) -> Option<Point> {
        (det > 0.0 || det < 0.0) {
         Some(Point {
             x: a.x + x,
-            y: a.y + y
+            y: a.y + y,
         })
     } else {
         None
@@ -202,9 +206,9 @@ fn counter_clockwise(p0: &Point, p1: &Point, p2: &Point) -> bool {
 }
 
 /// Returs the next halfedge for a given halfedge
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `i` - The current halfedge index
 pub fn next_halfedge(i: usize) -> usize {
     if i % 3 == 2 {
@@ -215,9 +219,9 @@ pub fn next_halfedge(i: usize) -> usize {
 }
 
 /// Returs the previous halfedge for a given halfedge
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `i` - The current halfedge index
 pub fn prev_halfedge(i: usize) -> usize {
     if i % 3 == 0 {
@@ -228,27 +232,27 @@ pub fn prev_halfedge(i: usize) -> usize {
 }
 
 /// Returns a vec containing indices for the 3 edges of a triangle t
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `t` - The triangle index
 pub fn edges_of_triangle(t: usize) -> [usize; 3] {
-    [3*t, 3*t + 1, 3*t + 2]
+    [3 * t, 3 * t + 1, 3 * t + 2]
 }
 
 /// Returns the triangle associated with the given edge
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `e` - The edge index
 pub fn triangle_of_edge(e: usize) -> usize {
     ((e as f64) / 3.).floor() as usize
 }
 
 /// Returns a vec containing the indices of the corners of the given triangle
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `t` - The triangle index
 /// * `delaunay` - A reference to a fully constructed Triangulation
 pub fn points_of_triangle(t: usize, delaunay: &Triangulation) -> Vec<usize> {
@@ -257,9 +261,9 @@ pub fn points_of_triangle(t: usize, delaunay: &Triangulation) -> Vec<usize> {
 }
 
 /// Returns a vec containing the indices for the adjacent triangles of the given triangle
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `t` - The triangle index
 /// * `delaunay` - A reference to a fully constructed Triangulation
 pub fn triangles_adjacent_to_triangle(t: usize, delaunay: &Triangulation) -> Vec<usize> {
@@ -274,9 +278,9 @@ pub fn triangles_adjacent_to_triangle(t: usize, delaunay: &Triangulation) -> Vec
 }
 
 /// Returns a vec containing all edges around a point
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `start` - The start point index
 /// * `delaunay` - A reference to a fully constructed Triangulation
 pub fn edges_around_point(start: usize, delaunay: &Triangulation) -> Vec<usize> {
@@ -294,7 +298,7 @@ pub fn edges_around_point(start: usize, delaunay: &Triangulation) -> Vec<usize> 
 }
 
 /// Represents a Delaunay triangulation for a given set of points. See example in [`delaunator`] for usage details.
-/// 
+///
 /// [`delaunator`]: ./index.html#example
 
 pub struct Triangulation {
@@ -305,11 +309,11 @@ pub struct Triangulation {
     /// A `Vec<usize>` array of indices that reference points on the convex hull of the input data, counter-clockwise.
     pub hull: Vec<usize>,
     /// A `Vec<usize>` that contains indices for halfedges of points in the hull that points inwards to the diagram. Only for [`voronator`] internal use.
-    /// 
+    ///
     /// [`voronator`]: ../index.html
     pub inedges: Vec<usize>,
     /// A `Vec<usize>` that contains indices for halfedges of points in the hull that points outwards to the diagram. Only for [`voronator`] internal use.
-    /// 
+    ///
     /// [`voronator`]: ../index.html
     pub outedges: Vec<usize>,
 }
@@ -333,26 +337,26 @@ impl Triangulation {
 
     fn legalize(&mut self, p: usize, points: &[Point], hull: &mut Hull) -> usize {
         /* if the pair of triangles doesn't satisfy the Delaunay condition
-        * (p1 is inside the circumcircle of [p0, pl, pr]), flip them,
-        * then do the same check/flip recursively for the new pair of triangles
-        *
-        *           pl                    pl
-        *          /||\                  /  \
-        *       al/ || \bl            al/    \a
-        *        /  ||  \              /      \
-        *       /  a||b  \    flip    /___ar___\
-        *     p0\   ||   /p1   =>   p0\---bl---/p1
-        *        \  ||  /              \      /
-        *       ar\ || /br             b\    /br
-        *          \||/                  \  /
-        *           pr                    pr
-        */
+         * (p1 is inside the circumcircle of [p0, pl, pr]), flip them,
+         * then do the same check/flip recursively for the new pair of triangles
+         *
+         *           pl                    pl
+         *          /||\                  /  \
+         *       al/ || \bl            al/    \a
+         *        /  ||  \              /      \
+         *       /  a||b  \    flip    /___ar___\
+         *     p0\   ||   /p1   =>   p0\---bl---/p1
+         *        \  ||  /              \      /
+         *       ar\ || /br             b\    /br
+         *          \||/                  \  /
+         *           pr                    pr
+         */
         let mut i: usize = 0;
         let mut ar;
         let mut a = p;
 
         let mut edge_stack: Vec<usize> = Vec::new();
-        
+
         loop {
             let b = self.halfedges[a];
             ar = prev_halfedge(a);
@@ -363,28 +367,25 @@ impl Triangulation {
                     a = edge_stack[i];
                     continue;
                 } else {
-                    break
+                    break;
                 }
             }
 
             let al = next_halfedge(a);
             let bl = prev_halfedge(b);
-            
+
             let p0 = self.triangles[ar];
             let pr = self.triangles[a];
             let pl = self.triangles[al];
             let p1 = self.triangles[bl];
 
-            let illegal = in_circle(&points[p1], 
-                                    &points[p0], 
-                                    &points[pr], 
-                                    &points[pl]);
+            let illegal = in_circle(&points[p1], &points[p0], &points[pr], &points[pl]);
             if illegal {
                 self.triangles[a] = p1;
                 self.triangles[b] = p0;
 
                 let hbl = self.halfedges[bl];
-                
+
                 // Edge swapped on the other side of the hull (rare).
                 // Fix the halfedge reference
                 if hbl == INVALID_INDEX {
@@ -394,9 +395,9 @@ impl Triangulation {
                             hull.tri[e] = a;
                             break;
                         }
-                        
+
                         e = hull.prev[e];
-                        
+
                         if e == hull.start {
                             break;
                         }
@@ -416,14 +417,12 @@ impl Triangulation {
                 }
 
                 i += 1;
+            } else if i > 0 {
+                i -= 1;
+                a = edge_stack[i];
+                continue;
             } else {
-                if i > 0 {
-                    i -= 1;
-                    a = edge_stack[i];
-                    continue;
-                } else {
-                    break;
-                }
+                break;
             }
         }
 
@@ -440,7 +439,6 @@ impl Triangulation {
         } else {
             // todo: fix hard error, make it recoverable or graceful
             panic!("Cannot link edge")
-
         }
 
         if b != INVALID_INDEX {
@@ -456,13 +454,15 @@ impl Triangulation {
         }
     }
 
-    fn add_triangle(&mut self, 
-                    i0: usize, 
-                    i1: usize, 
-                    i2: usize, 
-                    a: usize, 
-                    b: usize, 
-                    c: usize) -> usize {
+    fn add_triangle(
+        &mut self,
+        i0: usize,
+        i1: usize,
+        i2: usize,
+        a: usize,
+        b: usize,
+        c: usize,
+    ) -> usize {
         let t: usize = self.triangles.len();
 
         // eprintln!("adding triangle [{}, {}, {}]", i0, i1, i2);
@@ -480,7 +480,7 @@ impl Triangulation {
 }
 
 //@see https://stackoverflow.com/questions/33333363/built-in-mod-vs-custom-mod-function-improve-the-performance-of-modulus-op/33333636#33333636
-fn fast_mod(i: usize, c: usize) -> usize{
+fn fast_mod(i: usize, c: usize) -> usize {
     if i >= c {
         i % c
     } else {
@@ -488,7 +488,7 @@ fn fast_mod(i: usize, c: usize) -> usize{
     }
 }
 
-// monotonically increases with real angle, 
+// monotonically increases with real angle,
 // but doesn't need expensive trigonometry
 fn pseudo_angle(d: &Point) -> f64 {
     let p = d.x / (d.x.abs() + d.y.abs());
@@ -505,7 +505,7 @@ struct Hull {
     tri: Vec<usize>,
     hash: Vec<usize>,
     start: usize,
-    center: Point
+    center: Point,
 }
 
 impl Hull {
@@ -534,7 +534,7 @@ impl Hull {
         hull.tri[i2] = 2;
 
         // todo here
-        
+
         hull.hash_edge(&points[i0], i0);
         hull.hash_edge(&points[i1], i1);
         hull.hash_edge(&points[i2], i2);
@@ -544,10 +544,10 @@ impl Hull {
 
     fn hash_key(&self, p: &Point) -> usize {
         let d = Point::vector(&self.center, p);
-        
+
         let angle: f64 = pseudo_angle(&d);
         let len = self.hash.len();
-        
+
         fast_mod((angle * (len as f64)).floor() as usize, len)
     }
 
@@ -585,8 +585,8 @@ impl Hull {
         loop {
             q = self.next[e];
             // eprintln!("p: {:?}, e: {:?}, q: {:?}", p, &points[e], &points[q]);
-            if Point::equals_with_span(p, &points[e], span) ||
-               Point::equals_with_span(p, &points[q], span) 
+            if Point::equals_with_span(p, &points[e], span)
+                || Point::equals_with_span(p, &points[q], span)
             {
                 e = INVALID_INDEX;
                 break;
@@ -606,8 +606,14 @@ impl Hull {
 }
 
 fn calculate_bbox_center(points: &[Point]) -> (Point, f64) {
-    let mut max = Point{x: f64::NEG_INFINITY, y: f64::NEG_INFINITY};
-    let mut min = Point{x: f64::INFINITY, y: f64::INFINITY };
+    let mut max = Point {
+        x: f64::NEG_INFINITY,
+        y: f64::NEG_INFINITY,
+    };
+    let mut min = Point {
+        x: f64::INFINITY,
+        y: f64::INFINITY,
+    };
 
     for point in points {
         min.x = min.x.min(point.x);
@@ -620,11 +626,13 @@ fn calculate_bbox_center(points: &[Point]) -> (Point, f64) {
     let height = max.y - min.y;
     let span = width * width + height * height;
 
-    (Point {
-        x: (min.x + max.x) / 2.0,
-        y: (min.y + max.y) / 2.0
-    },
-    span)
+    (
+        Point {
+            x: (min.x + max.x) / 2.0,
+            y: (min.y + max.y) / 2.0,
+        },
+        span,
+    )
 }
 
 fn find_closest_point(points: &[Point], p: &Point) -> usize {
@@ -635,7 +643,7 @@ fn find_closest_point(points: &[Point], p: &Point) -> usize {
         if i != k {
             let q = &points[i];
             let d = Point::dist2(&p, &q);
-            
+
             if d < min_dist && d > 0.0 {
                 k = i;
                 min_dist = d;
@@ -646,13 +654,13 @@ fn find_closest_point(points: &[Point], p: &Point) -> usize {
     k
 }
 
-fn find_seed_triangle(center: &Point, points: &[Point]) -> Option<(usize, usize, usize)> {      
+fn find_seed_triangle(center: &Point, points: &[Point]) -> Option<(usize, usize, usize)> {
     let i0 = find_closest_point(points, center);
     let p0 = &points[i0];
-    
+
     let mut i1 = find_closest_point(points, &p0);
     let p1 = &points[i1];
-    
+
     // find the third point which forms the smallest circumcircle
     // with the first two
     let mut min_radius = f64::MAX;
@@ -661,7 +669,7 @@ fn find_seed_triangle(center: &Point, points: &[Point]) -> Option<(usize, usize,
         if i != i0 && i != i1 {
             let p = &points[i];
             let r = circumradius(&p0, &p1, &p);
-            
+
             if r < min_radius {
                 i2 = i;
                 min_radius = r;
@@ -672,7 +680,6 @@ fn find_seed_triangle(center: &Point, points: &[Point]) -> Option<(usize, usize,
     if min_radius == f64::MAX {
         None
     } else {
-
         let p2 = &points[i2];
 
         if counter_clockwise(&p0, &p1, &p2) {
@@ -693,7 +700,10 @@ fn to_points(coords: &[f64]) -> Vec<Point> {
         if i == coords.len() {
             break;
         }
-        let p = Point{x: coords[i], y: coords[i+1]};
+        let p = Point {
+            x: coords[i],
+            y: coords[i + 1],
+        };
         points.push(p);
         i += 2;
     }
@@ -701,55 +711,53 @@ fn to_points(coords: &[f64]) -> Vec<Point> {
     points
 }
 
-/// Calculates the Delaunay triangulation, if it exists, for a given set of 2D 
-/// points. 
-/// 
+/// Calculates the Delaunay triangulation, if it exists, for a given set of 2D
+/// points.
+///
 /// Points are passed a flat array of `f64` of size `2n`, where n is the
-/// number of points and for each point `i`, `{x = 2i, y = 2i + 1}` and 
-/// converted internally to `delaunator::Point`. It returns both the triangulation 
-/// and the vector of `delaunator::Point` to be used, if desired. 
-/// 
+/// number of points and for each point `i`, `{x = 2i, y = 2i + 1}` and
+/// converted internally to `delaunator::Point`. It returns both the triangulation
+/// and the vector of `delaunator::Point` to be used, if desired.
+///
 /// # Arguments
-/// 
-/// * `coords` - A vector of `f64` of size `2n`, where for each point `i`, `x = 2i` 
-/// and y = `2i + 1`. 
+///
+/// * `coords` - A vector of `f64` of size `2n`, where for each point `i`, `x = 2i`
+/// and y = `2i + 1`.
 pub fn triangulate_from_arr(coords: &[f64]) -> Option<(Triangulation, Vec<Point>)> {
     let n = coords.len();
-    
+
     if n % 2 != 0 {
-        return None
+        return None;
     }
-    
+
     let points = to_points(coords);
     let triangulation = triangulate(&points)?;
 
     Some((triangulation, points))
 }
 
-/// Calculates the Delaunay triangulation, if it exists, for a given set of 2D 
-/// points. 
-/// 
+/// Calculates the Delaunay triangulation, if it exists, for a given set of 2D
+/// points.
+///
 /// Points are passed as a tuple, `(f64, f64)`, and converted internally
-/// to `delaunator::Point`. It returns both the triangulation and the vector of 
-/// Points to be used, if desired. 
-/// 
+/// to `delaunator::Point`. It returns both the triangulation and the vector of
+/// Points to be used, if desired.
+///
 /// # Arguments
-/// 
+///
 /// * `coords` - A vector of tuples, where each tuple is a `(f64, f64)`
 pub fn triangulate_from_tuple(coords: &[(f64, f64)]) -> Option<(Triangulation, Vec<Point>)> {
-    let points: Vec<Point> = coords.iter()
-        .map(|p| Point { x: p.0, y: p.1 })
-        .collect();
-    
+    let points: Vec<Point> = coords.iter().map(|p| Point { x: p.0, y: p.1 }).collect();
+
     let triangulation = triangulate(&points)?;
 
     Some((triangulation, points))
 }
 
 /// Calculates the Delaunay triangulation, if it exists, for a given set of 2D points
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `points` - The set of points
 pub fn triangulate(points: &[Point]) -> Option<Triangulation> {
     if points.len() < 3 {
@@ -761,7 +769,7 @@ pub fn triangulate(points: &[Point]) -> Option<Triangulation> {
     //eprintln!("calculating bbox and seeds...");
     let (center_bbox, span) = calculate_bbox_center(points);
     let (i0, i1, i2) = find_seed_triangle(&center_bbox, &points)?;
-    
+
     let p0 = &points[i0];
     let p1 = &points[i1];
     let p2 = &points[i2];
@@ -769,7 +777,7 @@ pub fn triangulate(points: &[Point]) -> Option<Triangulation> {
     let center = circumcenter(&p0, &p1, &p2).unwrap();
 
     //eprintln!("calculating dists...");
-    
+
     // Calculate the distances from the center once to avoid having to
     // calculate for each compare.
     let mut dists: Vec<(usize, f64)> = points
@@ -780,16 +788,18 @@ pub fn triangulate(points: &[Point]) -> Option<Triangulation> {
 
     // sort the points by distance from the seed triangle circumcenter
     dists.sort_unstable_by(|(_, a), (_, b)| a.partial_cmp(&b).unwrap());
-    
+
     //eprintln!("creating hull...");
     let mut hull = Hull::new(points.len(), &center, i0, i1, i2, points);
 
     //eprintln!("calculating triangulation...");
     let mut triangulation = Triangulation::new(points.len());
-    triangulation.add_triangle(i0, i1, i2, 
-        INVALID_INDEX, INVALID_INDEX, INVALID_INDEX);
+    triangulation.add_triangle(i0, i1, i2, INVALID_INDEX, INVALID_INDEX, INVALID_INDEX);
 
-    let mut pp = Point{x: f64::NAN, y: f64::NAN};
+    let mut pp = Point {
+        x: f64::NAN,
+        y: f64::NAN,
+    };
 
     //eprintln!("iterating points...");
     // go through points based on distance from the center.
@@ -814,13 +824,17 @@ pub fn triangulate(points: &[Point]) -> Option<Triangulation> {
             continue;
         }
 
-        // add the first triangle from the point        
+        // add the first triangle from the point
         // eprintln!("first triangle of iteration");
         let mut t = triangulation.add_triangle(
-            e, i, hull.next[e], 
-            INVALID_INDEX, INVALID_INDEX, hull.tri[e]
+            e,
+            i,
+            hull.next[e],
+            INVALID_INDEX,
+            INVALID_INDEX,
+            hull.tri[e],
         );
-        
+
         hull.tri[i] = triangulation.legalize(t + 2, points, &mut hull);
         hull.tri[e] = t;
 
@@ -833,16 +847,15 @@ pub fn triangulate(points: &[Point]) -> Option<Triangulation> {
             if !counter_clockwise(p, &points[next], &points[q]) {
                 break;
             }
-            t = triangulation.add_triangle(next, i, q, hull.tri[i], 
-                INVALID_INDEX, hull.tri[next]);
-            
+            t = triangulation.add_triangle(next, i, q, hull.tri[i], INVALID_INDEX, hull.tri[next]);
+
             hull.tri[i] = triangulation.legalize(t + 2, points, &mut hull);
             hull.next[next] = next;
             next = q;
         }
 
         //eprintln!("walking backwards in hull...");
-        // walk backward from the other side, adding more triangles 
+        // walk backward from the other side, adding more triangles
         // and flipping
         if backwards {
             loop {
@@ -850,8 +863,7 @@ pub fn triangulate(points: &[Point]) -> Option<Triangulation> {
                 if !counter_clockwise(p, &points[q], &points[e]) {
                     break;
                 }
-                t = triangulation.add_triangle(q, i, e, INVALID_INDEX, 
-                    hull.tri[e], hull.tri[q]);
+                t = triangulation.add_triangle(q, i, e, INVALID_INDEX, hull.tri[e], hull.tri[q]);
                 triangulation.legalize(t + 2, points, &mut hull);
                 hull.tri[q] = t;
                 hull.next[e] = e;
@@ -872,8 +884,9 @@ pub fn triangulate(points: &[Point]) -> Option<Triangulation> {
 
     for e in 0..triangulation.triangles.len() {
         let endpoint = triangulation.triangles[next_halfedge(e)];
-        if triangulation.halfedges[e] == INVALID_INDEX ||
-           triangulation.inedges[endpoint] == INVALID_INDEX {
+        if triangulation.halfedges[e] == INVALID_INDEX
+            || triangulation.inedges[endpoint] == INVALID_INDEX
+        {
             triangulation.inedges[endpoint] = e;
         }
     }
@@ -899,8 +912,6 @@ pub fn triangulate(points: &[Point]) -> Option<Triangulation> {
             break;
         }
     }
-
-
 
     //eprintln!("done");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,35 +1,35 @@
 #![warn(missing_docs)]
 #![warn(missing_doc_code_examples)]
 //! Constructs a Voronoi diagram given a set of points.
-//! 
-//! This module was adapted from [d3-delaunay](https://github.com/d3/d3-delaunay) and from 
+//!
+//! This module was adapted from [d3-delaunay](https://github.com/d3/d3-delaunay) and from
 //! [Red Blog Games](https://www.redblobgames.com/x/2022-voronoi-maps-tutorial/) Voronoi maps tutorial.
-//! It implements the Delaunay triangulation dual extraction, which is the Voronoi diagram. 
+//! It implements the Delaunay triangulation dual extraction, which is the Voronoi diagram.
 //! It also implements a centroidal tesselation based on the Voronoi diagram, but using centroids
-//! instead of circumcenters for the vertices of the cell polygons. 
-//! 
-//! Apart from the triangle center they are using, the Voronoi and Centroidal diagrams differ 
+//! instead of circumcenters for the vertices of the cell polygons.
+//!
+//! Apart from the triangle center they are using, the Voronoi and Centroidal diagrams differ
 //! in how they handle the hull cells. The Voronoi diagram implements a clipping algorithm that
-//! clips the diagram into a bounding box, thus extracting neat polygons around the hull. The 
-//! Centroid diagram, in the other hand, doesn't. The outer cells can be missing or be distorted, 
+//! clips the diagram into a bounding box, thus extracting neat polygons around the hull. The
+//! Centroid diagram, in the other hand, doesn't. The outer cells can be missing or be distorted,
 //! as triangles calculated by the Delaunay triangulation can be too thin in the hull, causing
 //! centroid calculation to be "bad".
-//! 
-//! If you have a robust solution for this particular problem, please let me know either by 
+//!
+//! If you have a robust solution for this particular problem, please let me know either by
 //! creating an issue or through a pull-request, and I will make sure to add your solution with
 //! the proper credits.
-//! 
+//!
 //! # Example
-//! 
+//!
 //! ## Voronoi Diagram
 //! ```rust
 //! extern crate voronator;
 //! extern crate rand;
-//! 
+//!
 //! use voronator::VoronoiDiagram;
 //! use rand::prelude::*;
 //! use rand::distributions::Uniform;
-//! 
+//!
 //! fn main() {
 //!     let mut rng = rand::thread_rng();
 //!     let range1 = Uniform::new(0., 100.);
@@ -37,7 +37,7 @@
 //!     let mut points: Vec<(f64, f64)> = (0..10)
 //!         .map(|_| (rng.sample(&range1), rng.sample(&range2)))
 //!         .collect();
-//! 
+//!
 //!     let diagram = VoronoiDiagram::from_tuple(&(0., 0.), &(100., 100.), &points).unwrap();
 //!     
 //!     for cell in diagram.cells {
@@ -49,16 +49,16 @@
 //!     }
 //! }
 //! ```
-//! 
+//!
 //! ## Centroidal Tesselation Diagram
 //! ```rust
 //! extern crate voronator;
 //! extern crate rand;
-//! 
+//!
 //! use voronator::CentroidDiagram;
 //! use rand::prelude::*;
 //! use rand::distributions::Uniform;
-//! 
+//!
 //! fn main() {
 //!     let mut rng = rand::thread_rng();
 //!     let range1 = Uniform::new(0., 100.);
@@ -66,7 +66,7 @@
 //!     let mut points: Vec<(f64, f64)> = (0..10)
 //!         .map(|_| (rng.sample(&range1), rng.sample(&range2)))
 //!         .collect();
-//! 
+//!
 //!     let diagram = CentroidDiagram::from_tuple(&points).unwrap();
 //!     
 //!     for cell in diagram.cells {
@@ -79,21 +79,21 @@
 //! }
 //! ```
 
-pub mod delaunator;
 mod clip;
+pub mod delaunator;
 
 use std::{f64, usize};
 use vec;
 
-use crate::delaunator::*;
 use crate::clip::{clip_finite, clip_infinite};
+use crate::delaunator::*;
 
 /// Represents a centroidal tesselation diagram.
 pub struct CentroidDiagram {
     /// Contains the input data
     pub sites: Vec<Point>,
     /// A [`Triangulation`] struct that contains the Delaunay triangulation information.
-    /// 
+    ///
     /// [`Triangulation`]: ./delaunator/struct.Triangulation.html
     pub delaunay: Triangulation,
     /// Stores the centroid of each triangle
@@ -106,7 +106,7 @@ pub struct CentroidDiagram {
 
 impl CentroidDiagram {
     /// Creates a centroidal tesselation, if it exists, for a given set of points.
-    /// 
+    ///
     /// Points are represented here as a `delaunator::Point`.
     pub fn new(points: &[Point]) -> Option<Self> {
         let delaunay = triangulate(points)?;
@@ -123,25 +123,32 @@ impl CentroidDiagram {
     }
 
     /// Creates a centroidal tesselation, if it exists, for a given set of points.
-    /// 
+    ///
     /// Points are represented here as a `(f64, f64)` tuple.
     pub fn from_tuple(coords: &[(f64, f64)]) -> Option<Self> {
-        let points: Vec<Point> = coords.into_iter().map(|p| Point{x: p.0, y: p.1}).collect();
+        let points: Vec<Point> = coords
+            .into_iter()
+            .map(|p| Point { x: p.0, y: p.1 })
+            .collect();
         CentroidDiagram::new(&points)
     }
 
-    fn calculate_polygons(points: &[Point], centers: &[Point], delaunay: &Triangulation) -> Vec<Vec<Point>> {
+    fn calculate_polygons(
+        points: &[Point],
+        centers: &[Point],
+        delaunay: &Triangulation,
+    ) -> Vec<Vec<Point>> {
         let mut polygons: Vec<Vec<Point>> = vec![];
-    
+
         for t in 0..points.len() {
             let incoming = delaunay.inedges[t];
             let edges = edges_around_point(incoming, delaunay);
             let triangles: Vec<usize> = edges.into_iter().map(triangle_of_edge).collect();
             let polygon: Vec<Point> = triangles.into_iter().map(|t| centers[t].clone()).collect();
-            
+
             polygons.push(polygon);
         }
-    
+
         polygons
     }
 }
@@ -151,7 +158,7 @@ pub struct VoronoiDiagram {
     /// Contains the input data
     pub sites: Vec<Point>,
     /// A [`Triangulation`] struct that contains the Delaunay triangulation information.
-    /// 
+    ///
     /// [`Triangulation`]: ./delaunator/struct.Triangulation.html
     pub delaunay: Triangulation,
     /// Stores the circumcenter of each triangle
@@ -164,14 +171,15 @@ pub struct VoronoiDiagram {
 
 impl VoronoiDiagram {
     /// Creates a Voronoi diagram, if it exists, for a given set of points.
-    /// 
+    ///
     /// Points are represented here as a [`delaunator::Point`].
     /// [`delaunator::Point`]: ./delaunator/struct.Point.html
     pub fn new(min: &Point, max: &Point, points: &[Point]) -> Option<Self> {
         let delaunay = triangulate(points)?;
         let centers = calculate_circumcenters(points, &delaunay);
         let vectors = VoronoiDiagram::calculate_clip_vectors(points, &delaunay);
-        let cells = VoronoiDiagram::calculate_polygons(points, &centers, &vectors, &delaunay, min, max);
+        let cells =
+            VoronoiDiagram::calculate_polygons(points, &centers, &vectors, &delaunay, min, max);
         let neighbors = calculate_neighbors(points, &delaunay);
         Some(VoronoiDiagram {
             sites: points.to_vec(),
@@ -183,20 +191,23 @@ impl VoronoiDiagram {
     }
 
     /// Creates a Voronoi diagram, if it exists, for a given set of points.
-    /// 
+    ///
     /// Points are represented here as a `(f64, f64)` tuple.
     pub fn from_tuple(min: &(f64, f64), max: &(f64, f64), coords: &[(f64, f64)]) -> Option<Self> {
-        let points: Vec<Point> = coords.into_iter().map(|p| Point{x: p.0, y: p.1}).collect();
-        let min = Point{x: min.0, y: min.1};
-        let max = Point{x: max.0, y: max.1};
+        let points: Vec<Point> = coords
+            .into_iter()
+            .map(|p| Point { x: p.0, y: p.1 })
+            .collect();
+        let min = Point { x: min.0, y: min.1 };
+        let max = Point { x: max.0, y: max.1 };
         VoronoiDiagram::new(&min, &max, &points)
     }
 
     fn calculate_clip_vectors(points: &[Point], delaunay: &Triangulation) -> Vec<Point> {
-        let mut vectors: Vec<Point> = vec![Point{x: 0., y: 0.}; 2 * points.len()];
+        let mut vectors: Vec<Point> = vec![Point { x: 0., y: 0. }; 2 * points.len()];
         let mut i = 0;
         let mut node = delaunay.hull[0];
-        let mut i0: usize; 
+        let mut i0: usize;
         let mut i1: usize = node * 2;
         let mut p0: &Point;
         let mut p1: &Point = &points[node];
@@ -223,10 +234,16 @@ impl VoronoiDiagram {
         vectors
     }
 
-    fn calculate_polygons(points: &[Point], centers: &[Point], vectors: &[Point], 
-                          delaunay: &Triangulation, min: &Point, max: &Point) -> Vec<Vec<Point>> {
+    fn calculate_polygons(
+        points: &[Point],
+        centers: &[Point],
+        vectors: &[Point],
+        delaunay: &Triangulation,
+        min: &Point,
+        max: &Point,
+    ) -> Vec<Vec<Point>> {
         let mut polygons: Vec<Vec<Point>> = vec![];
-    
+
         for t in 0..points.len() {
             let incoming = delaunay.inedges[t];
             let edges = edges_around_point(incoming, delaunay);
@@ -235,7 +252,7 @@ impl VoronoiDiagram {
 
             let v = t * 2;
             let vertices = if vectors[v].x != 0. || vectors[v].y != 0. {
-                clip_infinite(&polygon, &vectors[v], &vectors[v+1], min, max)
+                clip_infinite(&polygon, &vectors[v], &vectors[v + 1], min, max)
             } else {
                 clip_finite(&polygon, min, max)
             };
@@ -243,33 +260,36 @@ impl VoronoiDiagram {
             if vertices.len() == 0 {
                 continue;
             }
-            
+
             polygons.push(vertices);
         }
-    
+
         polygons
     }
 }
 
 fn calculate_centroids(points: &[Point], delaunay: &Triangulation) -> Vec<Point> {
     let num_triangles = delaunay.len();
-    let mut centroids = vec![Point{x: 0., y: 0.}; num_triangles];
+    let mut centroids = vec![Point { x: 0., y: 0. }; num_triangles];
     for t in 0..num_triangles {
-        let mut sum = Point {x: 0., y: 0.};
+        let mut sum = Point { x: 0., y: 0. };
         for i in 0..3 {
             let s = 3 * t + i; // triangle coord index
             let p = &points[delaunay.triangles[s]];
             sum.x += p.x;
             sum.y += p.y;
         }
-        centroids[t] = Point{x: sum.x / 3., y: sum.y / 3.};
+        centroids[t] = Point {
+            x: sum.x / 3.,
+            y: sum.y / 3.,
+        };
     }
     centroids
 }
 
 fn calculate_circumcenters(points: &[Point], delaunay: &Triangulation) -> Vec<Point> {
     let num_triangles = delaunay.len();
-    let mut circumceters = vec![Point{x: 0., y: 0.}; num_triangles];
+    let mut circumceters = vec![Point { x: 0., y: 0. }; num_triangles];
     for t in 0..num_triangles {
         let v: Vec<Point> = points_of_triangle(t, delaunay)
             .into_iter()
@@ -286,7 +306,7 @@ fn calculate_circumcenters(points: &[Point], delaunay: &Triangulation) -> Vec<Po
 fn calculate_neighbors(points: &[Point], delaunay: &Triangulation) -> Vec<Vec<usize>> {
     let num_points = points.len();
     let mut neighbors: Vec<Vec<usize>> = vec![vec![]; num_points];
-    
+
     for t in 0..num_points {
         let e0 = delaunay.inedges[t];
         if e0 == INVALID_INDEX {
@@ -312,4 +332,3 @@ fn calculate_neighbors(points: &[Point], delaunay: &Triangulation) -> Vec<Vec<us
 
     neighbors
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,6 @@ mod clip;
 pub mod delaunator;
 
 use std::{f64, usize};
-use vec;
 
 use crate::clip::{clip_finite, clip_infinite};
 use crate::delaunator::*;
@@ -115,10 +114,10 @@ impl CentroidDiagram {
         let neighbors = calculate_neighbors(points, &delaunay);
         Some(CentroidDiagram {
             sites: points.to_vec(),
-            delaunay: delaunay,
-            centers: centers,
-            cells: cells,
-            neighbors: neighbors,
+            delaunay,
+            centers,
+            cells,
+            neighbors,
         })
     }
 
@@ -126,10 +125,7 @@ impl CentroidDiagram {
     ///
     /// Points are represented here as a `(f64, f64)` tuple.
     pub fn from_tuple(coords: &[(f64, f64)]) -> Option<Self> {
-        let points: Vec<Point> = coords
-            .into_iter()
-            .map(|p| Point { x: p.0, y: p.1 })
-            .collect();
+        let points: Vec<Point> = coords.iter().map(|p| Point { x: p.0, y: p.1 }).collect();
         CentroidDiagram::new(&points)
     }
 
@@ -183,10 +179,10 @@ impl VoronoiDiagram {
         let neighbors = calculate_neighbors(points, &delaunay);
         Some(VoronoiDiagram {
             sites: points.to_vec(),
-            delaunay: delaunay,
-            centers: centers,
-            cells: cells,
-            neighbors: neighbors,
+            delaunay,
+            centers,
+            cells,
+            neighbors,
         })
     }
 
@@ -194,10 +190,7 @@ impl VoronoiDiagram {
     ///
     /// Points are represented here as a `(f64, f64)` tuple.
     pub fn from_tuple(min: &(f64, f64), max: &(f64, f64), coords: &[(f64, f64)]) -> Option<Self> {
-        let points: Vec<Point> = coords
-            .into_iter()
-            .map(|p| Point { x: p.0, y: p.1 })
-            .collect();
+        let points: Vec<Point> = coords.iter().map(|p| Point { x: p.0, y: p.1 }).collect();
         let min = Point { x: min.0, y: min.1 };
         let max = Point { x: max.0, y: max.1 };
         VoronoiDiagram::new(&min, &max, &points)
@@ -257,7 +250,7 @@ impl VoronoiDiagram {
                 clip_finite(&polygon, min, max)
             };
 
-            if vertices.len() == 0 {
+            if vertices.is_empty() {
                 continue;
             }
 

--- a/tests/delaunator.rs
+++ b/tests/delaunator.rs
@@ -1,9 +1,9 @@
-extern crate voronator;
 extern crate serde_json;
+extern crate voronator;
 
-use voronator::delaunator::{triangulate, Point, Triangulation, INVALID_INDEX, EPSILON};
 use std::f64;
 use std::fs::File;
+use voronator::delaunator::{triangulate, Point, Triangulation, EPSILON, INVALID_INDEX};
 
 #[test]
 fn basic() {
@@ -23,10 +23,18 @@ fn square() {
 
 #[test]
 fn issue_11() {
-    let points: Vec<Point> = vec![(516., 661.), (369., 793.), (426., 539.), (273., 525.), (204., 694.), (747., 750.), (454., 390.)]
-        .iter()
-        .map(|p| Point { x: p.0, y: p.1 })
-        .collect();
+    let points: Vec<Point> = vec![
+        (516., 661.),
+        (369., 793.),
+        (426., 539.),
+        (273., 525.),
+        (204., 694.),
+        (747., 750.),
+        (454., 390.),
+    ]
+    .iter()
+    .map(|p| Point { x: p.0, y: p.1 })
+    .collect();
 
     validate(&points);
 }
@@ -39,10 +47,20 @@ fn issue_13() {
 
 #[test]
 fn issue_24() {
-    let points: Vec<Point> = vec![(382., 302.), (382., 328.), (382., 205.), (623., 175.), (382., 188.), (382., 284.), (623., 87.), (623., 341.), (141., 227.)]
-        .iter()
-        .map(|p| Point { x: p.0, y: p.1 })
-        .collect();
+    let points: Vec<Point> = vec![
+        (382., 302.),
+        (382., 328.),
+        (382., 205.),
+        (623., 175.),
+        (382., 188.),
+        (382., 284.),
+        (623., 87.),
+        (623., 341.),
+        (141., 227.),
+    ]
+    .iter()
+    .map(|p| Point { x: p.0, y: p.1 })
+    .collect();
 
     validate(&points);
 }
@@ -62,13 +80,13 @@ fn issue_44() {
 #[test]
 fn robustness() {
     let robustness1 = load_fixture("tests/fixtures/robustness1.json");
-    
+
     validate(&robustness1);
     validate(&(scale_points(&robustness1, 1e-9)));
     validate(&(scale_points(&robustness1, 1e-2)));
     validate(&(scale_points(&robustness1, 100.0)));
     validate(&(scale_points(&robustness1, 1e9)));
-    
+
     let robustness2 = load_fixture("tests/fixtures/robustness2.json");
     validate(&robustness2[0..100]);
     validate(&robustness2);
@@ -77,7 +95,7 @@ fn robustness() {
 #[test]
 fn few_points() {
     let points = load_fixture("tests/fixtures/ukraine.json");
-    
+
     let d = triangulate(&points[0..0]);
     assert!(d.is_none());
 
@@ -91,7 +109,7 @@ fn few_points() {
 #[test]
 fn collinear() {
     let points: Vec<Point> = vec![(0., 0.), (1., 0.), (3., 0.), (2., 0.)]
-       .iter()
+        .iter()
         .map(|p| Point { x: p.0, y: p.1 })
         .collect();
 
@@ -105,7 +123,8 @@ fn scale_points(points: &[Point], scale: f64) -> Vec<Point> {
         .map(|p| Point {
             x: p.x * scale,
             y: p.y * scale,
-        }).collect();
+        })
+        .collect();
     scaled
 }
 
@@ -120,10 +139,9 @@ fn triangle_area(points: &[Point], delaunay: &Triangulation) -> f64 {
     let mut t = 0;
     while t < delaunay.triangles.len() {
         let a = &points[delaunay.triangles[t]];
-        let b = &points[delaunay.triangles[t+1]];
-        let c = &points[delaunay.triangles[t+2]];
-        let val = ((b.y - a.y) * (c.x - b.x) - 
-                   (b.x - a.x) * (c.y - b.y)).abs();
+        let b = &points[delaunay.triangles[t + 1]];
+        let c = &points[delaunay.triangles[t + 2]];
+        let val = ((b.y - a.y) * (c.x - b.x) - (b.x - a.x) * (c.y - b.y)).abs();
         vals.push(val);
         t += 3;
     }


### PR DESCRIPTION

Clippy warnings

- redundant field names in struct initialization
-  length comparison to zero
-  manual swap
-  into_iter_on_ref

Clippy errors

- strict comparison of `f32` or `f64`
- cloning double reference