### PR TITLE
If the starting point is invalid then edges_around_point causes overflow

### DIFF
--- a/src/delaunator.rs
+++ b/src/delaunator.rs
@@ -282,6 +282,12 @@ pub fn triangles_adjacent_to_triangle(t: usize, delaunay: &Triangulation) -> Vec
 /// * `delaunay` - A reference to a fully constructed Triangulation
 pub fn edges_around_point(start: usize, delaunay: &Triangulation) -> Vec<usize> {
     let mut result: Vec<usize> = vec![];
+
+    // If the starting index is invalid we can't continue
+    if start == INVALID_INDEX {
+        return result;
+    }
+
     let mut incoming = start;
     loop {
         result.push(incoming);


### PR DESCRIPTION
If the starting point is an invalid index when `edges_around_point` is called, then an overflow occurs. I am not sure why the point was marked as invalid, but this check at least allowed everything to run to completion.