### PR TITLE
Fix #12 - Make rayon optional with maybe_parallel_iterator.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ description = "Implements the Voronoi diagram construction as a dual of the Dela
 categories = ["algorithms", "data-structures", "graphics", "visualization"]
 keywords = ["voronoi", "delaunay", "diagram"]
 
+[features]
+default = ["rayon"]
+rayon = ["maybe_parallel_iterator/rayon"]
+
 [dependencies]
-rayon = "1.5"
+maybe_parallel_iterator = "0.12.0"
 
 [dev-dependencies]
 criterion = "0.3.2"

--- a/src/delaunator.rs
+++ b/src/delaunator.rs
@@ -54,8 +54,7 @@
 //! [`halfedges`]: ./struct.Triangulation.html#structfield.halfedges
 //! [`hull`]: ./struct.Triangulation.html#structfield.hull
 
-
-use rayon::prelude::*;
+use maybe_parallel_iterator::IntoMaybeParallelRefIterator;
 use std::{f64, fmt, usize};
 
 /// Defines a comparison epsilon used for floating-point comparisons
@@ -837,7 +836,7 @@ pub fn triangulate<C: Coord + Vector<C>>(points: &[C]) -> Option<Triangulation> 
     // Calculate the distances from the center once to avoid having to
     // calculate for each compare.
     let mut dists: Vec<(usize, f64)> = points
-        .par_iter()
+        .maybe_par_iter()
         .enumerate()
         .map(|(i, _)| (i, C::dist2(&points[i], &center)))
         .collect();

--- a/src/delaunator.rs
+++ b/src/delaunator.rs
@@ -54,6 +54,7 @@
 //! [`halfedges`]: ./struct.Triangulation.html#structfield.halfedges
 //! [`hull`]: ./struct.Triangulation.html#structfield.hull
 
+
 use maybe_parallel_iterator::IntoMaybeParallelRefIterator;
 use std::{f64, fmt, usize};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,9 +84,8 @@
 pub mod polygon;
 pub mod delaunator;
 
-use rayon::prelude::*;
-
 use std::{f64, usize};
+use maybe_parallel_iterator::{IntoMaybeParallelIterator, IntoMaybeParallelRefIterator};
 
 use crate::delaunator::*;
 use crate::polygon::*;
@@ -273,7 +272,7 @@ impl<C: Coord + Vector<C>> VoronoiDiagram<C> {
         delaunay: &Triangulation,
         clip_polygon: &Polygon<C>,
     ) -> Vec<Polygon<C>> {
-        points.par_iter().enumerate().map(|(t, _point)| {
+        points.maybe_par_iter().enumerate().map(|(t, _point)| {
             let incoming = delaunay.inedges[t];
             let edges = edges_around_point(incoming, delaunay);
             let triangles: Vec<usize> = edges.into_iter().map(triangle_of_edge).collect();
@@ -307,7 +306,7 @@ fn calculate_centroids<C: Coord + Vector<C>>(points: &[C], delaunay: &Triangulat
 }
 
 fn calculate_circumcenters<C: Coord + Vector<C>>(points: &[C], delaunay: &Triangulation) -> Vec<C> {
-    (0..delaunay.len()).into_par_iter().map(|t| {
+    (0..delaunay.len()).into_maybe_par_iter().map(|t| {
         let v: Vec<C> = points_of_triangle(t, delaunay)
         .into_iter()
         .map(|p| points[p].clone())
@@ -321,7 +320,7 @@ fn calculate_circumcenters<C: Coord + Vector<C>>(points: &[C], delaunay: &Triang
 }
 
 fn calculate_neighbors<C: Coord + Vector<C>>(points: &[C], delaunay: &Triangulation) -> Vec<Vec<usize>> {
-    points.par_iter().enumerate().map(|(t, _point)| {
+    points.maybe_par_iter().enumerate().map(|(t, _point)| {
         let mut neighbours: Vec<usize> = vec![];
 
         let e0 = delaunay.inedges[t];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,8 @@
 pub mod polygon;
 pub mod delaunator;
 
-use std::{f64, usize};
 use maybe_parallel_iterator::{IntoMaybeParallelIterator, IntoMaybeParallelRefIterator};
+use std::{f64, usize};
 
 use crate::delaunator::*;
 use crate::polygon::*;


### PR DESCRIPTION
This PR introduces a dependency on `maybe_parallel_iterator` to make `rayon` optional, adding much better support for WebAssembly. The default is to use `rayon`, matching the old behavior. Clients can pass `default-features=false` in their `Cargo.toml` to avoid it.

Full disclosure: I am the author of `maybe_parallel_iterator`, which is currently a wrapper around `rayon`.

Fixes #12