### PR TITLE
Add common traits with derive macros

### DIFF
--- a/src/delaunator.rs
+++ b/src/delaunator.rs
@@ -146,7 +146,7 @@ pub trait Vector<C: Coord> {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, PartialOrd)]
 /// Represents a point in the 2D space.
 pub struct Point {
     /// X coordinate of the point
@@ -376,6 +376,7 @@ pub fn edges_around_point(start: usize, delaunay: &Triangulation) -> Vec<usize> 
 ///
 /// [`delaunator`]: ./index.html#example
 
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Triangulation {
     /// Contains the indices for each vertex of a triangle in the original array. All triangles are directed counter-clockwise.
     pub triangles: Vec<usize>,
@@ -574,6 +575,7 @@ fn pseudo_angle<C: Coord + Vector<C>>(d: &C) -> f64 {
     }
 }
 
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 struct Hull<C: Coord> {
     prev: Vec<usize>,
     next: Vec<usize>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ use crate::delaunator::*;
 use crate::polygon::*;
 
 /// Represents a centroidal tesselation diagram.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct CentroidDiagram<C: Coord + Vector<C>> {
     /// Contains the input data
     pub sites: Vec<C>,
@@ -185,6 +186,7 @@ fn helper_points<C: Coord>(polygon: &Polygon<C>) -> Vec<C> {
 }
 
 /// Represents a Voronoi diagram.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct VoronoiDiagram<C: Coord + Vector<C>> {
     /// Contains the input data
     pub sites: Vec<C>,

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -19,6 +19,7 @@
 use crate::delaunator::Coord;
 
 /// Represents a polygon.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Polygon<C: Coord> {
     pub(crate) points: Vec<C>,
 }


### PR DESCRIPTION
This PR adds implementation of common traits according to [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/checklist.html). 

Personally, I only need `Clone` for `Polygon` but I have added other implementations if someone needs them in the future. 

I did not implement `Default` and `Display` traits as thy require in-depth code analysis to implement them reasonably.

Crate passes all test with that change.